### PR TITLE
Fix missing export-ignore .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,8 @@ phpunit.xml export-ignore
 *.md export-ignore
 /tests export-ignore
 /packages-tests export-ignore
-/easy-ci.php
-/ecs.php
-/rector.php
-/phpunit.xml
-/phpstan.neon
+/easy-ci.php export-ignore
+/ecs.php export-ignore
+/rector.php export-ignore
+/phpunit.xml export-ignore
+/phpstan.neon export-ignore


### PR DESCRIPTION
To avoid issue like in https://github.com/rectorphp/rector-src/actions/runs/7822704957/job/21342292839#step:14:63 which dev files still included