### PR TITLE
Expand WorkerCommandLineFactory tests for the worker command string

### DIFF
--- a/tests/CommandLine/Source/TestOption.php
+++ b/tests/CommandLine/Source/TestOption.php
@@ -15,4 +15,14 @@ final class TestOption
      * @var string
      */
     public const OUTPUT_FORMAT = 'output-format';
+
+    /**
+     * @var string
+     */
+    public const FIX = 'fix';
+
+    /**
+     * @var string
+     */
+    public const MEMORY_LIMIT = 'memory-limit';
 }

--- a/tests/CommandLine/WorkerCommandLineFactoryTest.php
+++ b/tests/CommandLine/WorkerCommandLineFactoryTest.php
@@ -43,18 +43,82 @@ final class WorkerCommandLineFactoryTest extends TestCase
 
     public static function provideData(): Iterator
     {
-        $expectedCommandLinesString = self::createExpectedCommandLinesString();
+        yield 'no options, single path' => [[], ['src'], self::wrap('', "'src'")];
 
-        yield [[], ['src'], $expectedCommandLinesString];
+        yield 'output-format is excluded' => [
+            [TestOption::OUTPUT_FORMAT => 'console'],
+            ['src'],
+            self::wrap('', "'src'"),
+        ];
 
-        // output-format is excluded, so it must not change the result
-        yield [[TestOption::OUTPUT_FORMAT => 'console'], ['src'], $expectedCommandLinesString];
+        yield 'true bool option becomes a flag' => [
+            [TestOption::FIX => true],
+            ['src'],
+            self::wrap('--fix', "'src'"),
+        ];
+
+        yield 'false bool option is omitted' => [
+            [TestOption::FIX => false],
+            ['src'],
+            self::wrap('', "'src'"),
+        ];
+
+        yield 'null option is omitted' => [
+            [TestOption::MEMORY_LIMIT => null],
+            ['src'],
+            self::wrap('', "'src'"),
+        ];
+
+        yield 'memory-limit uses the assign form' => [
+            [TestOption::MEMORY_LIMIT => '-1'],
+            ['src'],
+            self::wrap('--memory-limit=-1', "'src'"),
+        ];
+
+        yield 'string option keeps the escaped value' => [
+            ['some-option' => 'value'],
+            ['src'],
+            self::wrap("--some-option 'value'", "'src'"),
+        ];
+
+        yield 'multiple paths are all escaped' => [[], ['src', 'tests'], self::wrap('', "'src' 'tests'")];
+
+        yield 'framework global options are excluded' => [
+            ['no-interaction' => true, 'verbose' => true, 'ansi' => true, 'help' => true],
+            ['src'],
+            self::wrap('', "'src'"),
+        ];
     }
 
-    private static function createExpectedCommandLinesString(): string
+    public function testProjectConfigFileIsPassedRightAfterWorkerName(): void
     {
-        $commandLineString = "'" . PHP_BINARY . "' '" . self::DUMMY_MAIN_SCRIPT . "'";
+        $workerCommandLine = $this->workerCommandLineFactory->create(
+            self::DUMMY_MAIN_SCRIPT,
+            'worker',
+            'ecs.php',
+            [],
+            ['src'],
+            'identifier',
+            2000
+        );
 
-        return $commandLineString . " worker --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi";
+        $expectedCommand = "'" . PHP_BINARY . "' '" . self::DUMMY_MAIN_SCRIPT
+            . "' worker --config 'ecs.php' --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi";
+
+        $this->assertSame($expectedCommand, $workerCommandLine);
+    }
+
+    /**
+     * Assemble the expected command line: options sit before --port, paths after --identifier.
+     */
+    private static function wrap(string $options, string $paths): string
+    {
+        $command = "'" . PHP_BINARY . "' '" . self::DUMMY_MAIN_SCRIPT . "' worker";
+
+        if ($options !== '') {
+            $command .= ' ' . $options;
+        }
+
+        return $command . " --port 2000 --identifier 'identifier' " . $paths . " --output-format 'json' --no-ansi";
     }
 }


### PR DESCRIPTION
Follow-up to #9. Locks down the exact worker command string built by `WorkerCommandLineFactory::create()`.

## Added cases

- bool option `true` → `--flag`, `false` → omitted
- `null` option → omitted
- `memory-limit` → assign form `--memory-limit=-1`
- string option → escaped value `--name 'value'`
- excluded framework globals (`no-interaction`, `verbose`, `ansi`, `help`, `output-format`) → omitted
- multiple paths → each escaped
- project config file → `--config 'ecs.php'` right after the `worker` command name

## Verified

- `phpunit` — 10 tests green
- `phpstan` — no errors